### PR TITLE
Add Kubernetes controller project and MongoDB upgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCorePackageVersion)" />
 	<!-- EF Core-->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftEntityFrameworkCorePackageVersion)" />
-	<PackageVersion Include="MongoDB.EntityFrameworkCore" Version="9.0.3" />
+	<PackageVersion Include="MongoDB.EntityFrameworkCore" Version="9.0.4" />
     <!-- Extensions -->
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsPackageVersion)" />

--- a/Sail.slnx
+++ b/Sail.slnx
@@ -12,6 +12,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Sail.Database.MongoDB/Sail.Database.MongoDB.csproj" />
+    <Project Path="src/Sail.Kubernetes.Controller/Sail.Kubernetes.Controller.csproj" Id="189c2523-d41f-487f-8571-9d6e556edc3d" />
     <Project Path="src\Sail.Compass\Sail.Compass.csproj" />
     <Project Path="src\Sail.Core\Sail.Core.csproj" />
     <Project Path="src\Sail.Proxy\Sail.Proxy.csproj" />

--- a/src/Sail.Compass/ConfigProvider/ProxyConfigProvider.cs
+++ b/src/Sail.Compass/ConfigProvider/ProxyConfigProvider.cs
@@ -263,4 +263,3 @@ internal sealed class ProxyConfigProvider : IProxyConfigProvider, IDisposable
         }
     }
 }
-

--- a/src/Sail.Core/Certificates/ServerCertificateSelector.cs
+++ b/src/Sail.Core/Certificates/ServerCertificateSelector.cs
@@ -21,7 +21,6 @@ public class ServerCertificateSelector(
         new Dictionary<string, X509Certificate2>(StringComparer.OrdinalIgnoreCase);
 
     private X509Certificate2? _defaultCertificate;
-
     public IReadOnlyDictionary<string, X509Certificate2> Certificates => _certificates;
 
     public IReadOnlyDictionary<string, X509Certificate2> WildcardCertificates => _wildcardCertificates;

--- a/src/Sail.Core/OutputCache/SailOutputCachePolicyProvider.cs
+++ b/src/Sail.Core/OutputCache/SailOutputCachePolicyProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Sail.Core.OutputCache;
+
+public class SailOutputCachePolicyProvider
+{
+
+}

--- a/src/Sail.Core/Retry/RetryMiddleware.cs
+++ b/src/Sail.Core/Retry/RetryMiddleware.cs
@@ -1,8 +1,8 @@
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Polly;
 using Sail.Core.Utilities;
 using Yarp.ReverseProxy.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Sail.Core.Retry;
 

--- a/src/Sail.Kubernetes.Controller/Queues/IWorkQueue.cs
+++ b/src/Sail.Kubernetes.Controller/Queues/IWorkQueue.cs
@@ -1,0 +1,5 @@
+﻿namespace Sail.Kubernetes.Controller.Queues;
+
+public interface IWorkQueue<TItem> : IDisposable
+{
+}

--- a/src/Sail.Kubernetes.Controller/Sail.Kubernetes.Controller.csproj
+++ b/src/Sail.Kubernetes.Controller/Sail.Kubernetes.Controller.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Sail/AuthenticationPolicy/Grpc/AuthenticationPolicyGrpcService.cs
+++ b/src/Sail/AuthenticationPolicy/Grpc/AuthenticationPolicyGrpcService.cs
@@ -2,7 +2,6 @@ using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Sail.Api.V1;
 using Sail.Core.Stores;
-using AuthenticationPolicyEntity = Sail.Core.Entities.AuthenticationPolicy;
 
 namespace Sail.AuthenticationPolicy.Grpc;
 

--- a/src/Sail/Program.cs
+++ b/src/Sail/Program.cs
@@ -1,20 +1,26 @@
-using Sail.Core.Entities;
-using Sail.Core.Management;
-using Sail.Extensions;
-using ServiceDefaults;
-using Sail.Database.MongoDB.Management;
 using System.Text.Json.Serialization;
-using Sail.Route.Grpc;
-using Sail.Route.Http;
-using Sail.Cluster.Grpc;
-using Sail.Cluster.Http;
-using Sail.Certificate.Grpc;
-using Sail.Certificate.Http;
-using Sail.Middleware.Grpc;
-using Sail.Middleware.Http;
+
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore;
+using MongoDB.EntityFrameworkCore.Metadata;
+
 using Sail.AuthenticationPolicy.Grpc;
 using Sail.AuthenticationPolicy.Http;
+using Sail.Certificate.Grpc;
+using Sail.Certificate.Http;
+using Sail.Cluster.Grpc;
+using Sail.Cluster.Http;
+using Sail.Core.Entities;
+using Sail.Core.Management;
+using Sail.Database.MongoDB.Management;
+using Sail.Extensions;
+using Sail.Middleware.Grpc;
+using Sail.Middleware.Http;
+using Sail.Route.Grpc;
+using Sail.Route.Http;
 using Sail.Statistics.Http;
+
+using ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -37,7 +43,18 @@ var app = builder.Build();
 using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<IContext>();
-    await context.Database.EnsureCreatedAsync();
+    var collectionOptions = new CreateCollectionOptions
+    {
+        ChangeStreamPreAndPostImagesOptions = new ChangeStreamPreAndPostImagesOptions
+        {
+            Enabled = true
+        }
+    };
+    var options = new MongoDatabaseCreationOptions()
+    {
+        CreateCollectionOptions = collectionOptions
+    };
+    await context.Database.EnsureCreatedAsync(options);
 }
 
 var endpoint = app.NewVersionedApi();


### PR DESCRIPTION
- Added Sail.Kubernetes.Controller project targeting .NET 9.0
- Updated MongoDB.EntityFrameworkCore to v9.0.4
- Introduced IWorkQueue<TItem> interface for work queue abstraction
- Added SailOutputCachePolicyProvider class (empty stub)
- Improved MongoDB database creation with change stream options
- Refactored Program.cs usings and service registration
- Performed minor formatting and namespace cleanups