### PR TITLE
Simplify service type references in HTTP endpoint builders

### DIFF
--- a/src/Sail/AuthenticationPolicy/Http/AuthenticationPolicyHttpEndpointsBuilder.cs
+++ b/src/Sail/AuthenticationPolicy/Http/AuthenticationPolicyHttpEndpointsBuilder.cs
@@ -24,7 +24,7 @@ public static class AuthenticationPolicyHttpEndpointsBuilder
     }
 
     private static async Task<IResult> GetAuthenticationPolicies(
-        [FromServices] AuthenticationPolicy.AuthenticationPolicyService service,
+        [FromServices] AuthenticationPolicyService service,
         CancellationToken cancellationToken)
     {
         var policies = await service.GetAsync(cancellationToken);
@@ -33,7 +33,7 @@ public static class AuthenticationPolicyHttpEndpointsBuilder
 
     private static async Task<IResult> GetAuthenticationPolicy(
         [FromRoute] Guid id,
-        [FromServices] AuthenticationPolicy.AuthenticationPolicyService service,
+        [FromServices] AuthenticationPolicyService service,
         CancellationToken cancellationToken)
     {
         var policy = await service.GetByIdAsync(id, cancellationToken);
@@ -42,7 +42,7 @@ public static class AuthenticationPolicyHttpEndpointsBuilder
 
     private static async Task<IResult> CreateAuthenticationPolicy(
         [FromBody] AuthenticationPolicyRequest request,
-        [FromServices] AuthenticationPolicy.AuthenticationPolicyService service,
+        [FromServices] AuthenticationPolicyService service,
         CancellationToken cancellationToken)
     {
         var policy = await service.CreateAsync(request, cancellationToken);
@@ -52,7 +52,7 @@ public static class AuthenticationPolicyHttpEndpointsBuilder
     private static async Task<IResult> UpdateAuthenticationPolicy(
         [FromRoute] Guid id,
         [FromBody] AuthenticationPolicyRequest request,
-        [FromServices] AuthenticationPolicy.AuthenticationPolicyService service,
+        [FromServices] AuthenticationPolicyService service,
         CancellationToken cancellationToken)
     {
         try
@@ -68,7 +68,7 @@ public static class AuthenticationPolicyHttpEndpointsBuilder
 
     private static async Task<IResult> DeleteAuthenticationPolicy(
         [FromRoute] Guid id,
-        [FromServices] AuthenticationPolicy.AuthenticationPolicyService service,
+        [FromServices] AuthenticationPolicyService service,
         CancellationToken cancellationToken)
     {
         await service.DeleteAsync(id, cancellationToken);

--- a/src/Sail/Certificate/Http/CertificateHttpEndpointsBuilder.cs
+++ b/src/Sail/Certificate/Http/CertificateHttpEndpointsBuilder.cs
@@ -27,7 +27,7 @@ public static class CertificateHttpEndpointsBuilder
         return api;
     }
 
-    private static async Task<Results<Ok<IEnumerable<SNIResponse>>, NotFound>> GetSNIs(Certificate.CertificateService service,
+    private static async Task<Results<Ok<IEnumerable<SNIResponse>>, NotFound>> GetSNIs(CertificateService service,
         Guid certificateId,
         CancellationToken cancellationToken)
     {
@@ -35,7 +35,7 @@ public static class CertificateHttpEndpointsBuilder
         return TypedResults.Ok(items);
     }
 
-    private static async Task<Results<Created, ProblemHttpResult>> CreateSNI(Certificate.CertificateService service,
+    private static async Task<Results<Created, ProblemHttpResult>> CreateSNI(CertificateService service,
         Guid certificateId, SNIRequest request, CancellationToken cancellationToken)
     {
         var result = await service.CreateSNIAsync(certificateId, request, cancellationToken);
@@ -46,7 +46,7 @@ public static class CertificateHttpEndpointsBuilder
         );
     }
 
-    private static async Task<Results<Ok, ProblemHttpResult>> UpdateSNI(Certificate.CertificateService service, Guid certificateId,
+    private static async Task<Results<Ok, ProblemHttpResult>> UpdateSNI(CertificateService service, Guid certificateId,
         Guid id, SNIRequest request, CancellationToken cancellationToken)
     {
         var result = await service.UpdateSNIAsync(certificateId, id, request, cancellationToken);
@@ -57,7 +57,7 @@ public static class CertificateHttpEndpointsBuilder
         );
     }
 
-    private static async Task<Results<Ok, ProblemHttpResult>> DeleteSNI(Certificate.CertificateService service, Guid certificateId,
+    private static async Task<Results<Ok, ProblemHttpResult>> DeleteSNI(CertificateService service, Guid certificateId,
         Guid id, CancellationToken cancellationToken)
     {
         var result = await service.DeleteSNIAsync(certificateId, id, cancellationToken);
@@ -69,7 +69,7 @@ public static class CertificateHttpEndpointsBuilder
     }
 
     private static async Task<Results<Ok<IEnumerable<CertificateResponse>>, NotFound>> GetItems(
-        Certificate.CertificateService service,
+        CertificateService service,
         CancellationToken cancellationToken)
     {
         var items = await service.GetAsync(cancellationToken);
@@ -77,7 +77,7 @@ public static class CertificateHttpEndpointsBuilder
     }
 
     private static async Task<Results<Ok<CertificateResponse>, NotFound>> GetItem(
-        Certificate.CertificateService service,
+        CertificateService service,
         Guid id,
         CancellationToken cancellationToken)
     {
@@ -85,7 +85,7 @@ public static class CertificateHttpEndpointsBuilder
         return item != null ? TypedResults.Ok(item) : TypedResults.NotFound();
     }
 
-    private static async Task<Results<Created, ProblemHttpResult>> Create(Certificate.CertificateService service,
+    private static async Task<Results<Created, ProblemHttpResult>> Create(CertificateService service,
         CertificateRequest request, CancellationToken cancellationToken)
     {
         var result = await service.CreateAsync(request, cancellationToken);
@@ -96,7 +96,7 @@ public static class CertificateHttpEndpointsBuilder
         );
     }
 
-    private static async Task<Results<Ok, ProblemHttpResult>> Update(Certificate.CertificateService service, Guid id,
+    private static async Task<Results<Ok, ProblemHttpResult>> Update(CertificateService service, Guid id,
         CertificateRequest request, CancellationToken cancellationToken)
     {
         var result = await service.UpdateAsync(id, request, cancellationToken);
@@ -106,8 +106,7 @@ public static class CertificateHttpEndpointsBuilder
             errors => errors.HandleErrors()
         );
     }
-
-    private static async Task<Results<Ok, ProblemHttpResult>> Delete(Certificate.CertificateService service, Guid id,
+    private static async Task<Results<Ok, ProblemHttpResult>> Delete(CertificateService service, Guid id,
         CancellationToken cancellationToken)
     {
         var result = await service.DeleteAsync(id, cancellationToken);

--- a/src/Sail/Cluster/Http/ClusterHttpEndpointsBuilder.cs
+++ b/src/Sail/Cluster/Http/ClusterHttpEndpointsBuilder.cs
@@ -20,14 +20,14 @@ public static class ClusterHttpEndpointsBuilder
         return api;
     }
 
-    private static async Task<Results<Ok<ClusterResponse>, NotFound>> Get(Cluster.ClusterService service,
+    private static async Task<Results<Ok<ClusterResponse>, NotFound>> Get(ClusterService service,
         Guid id,
         CancellationToken cancellationToken)
     {
         var items = await service.GetAsync(id, cancellationToken);
         return TypedResults.Ok(items);
     }
-    private static async Task<Results<Ok<IEnumerable<ClusterResponse>>, NotFound>> List(Cluster.ClusterService service,
+    private static async Task<Results<Ok<IEnumerable<ClusterResponse>>, NotFound>> List(ClusterService service,
         string? keywords,
         CancellationToken cancellationToken)
     {
@@ -35,7 +35,7 @@ public static class ClusterHttpEndpointsBuilder
         return TypedResults.Ok(items);
     }
 
-    private static async Task<Results<Created, ProblemHttpResult>> Create(Cluster.ClusterService service,
+    private static async Task<Results<Created, ProblemHttpResult>> Create(ClusterService service,
         ClusterRequest request, CancellationToken cancellationToken)
     {
         var result = await service.CreateAsync(request, cancellationToken);
@@ -46,7 +46,7 @@ public static class ClusterHttpEndpointsBuilder
         );
     }
 
-    private static async Task<Results<Ok, ProblemHttpResult>> Update(Cluster.ClusterService service, Guid id,
+    private static async Task<Results<Ok, ProblemHttpResult>> Update(ClusterService service, Guid id,
         ClusterRequest request, CancellationToken cancellationToken)
     {
         var result = await service.UpdateAsync(id, request, cancellationToken);
@@ -57,7 +57,7 @@ public static class ClusterHttpEndpointsBuilder
         );
     }
 
-    private static async Task<Results<Ok, ProblemHttpResult>> Delete(Cluster.ClusterService service, Guid id,
+    private static async Task<Results<Ok, ProblemHttpResult>> Delete(ClusterService service, Guid id,
         CancellationToken cancellationToken)
     {
         var result = await service.DeleteAsync(id, cancellationToken);

--- a/src/Sail/Middleware/Http/MiddlewareHttpEndpointsBuilder.cs
+++ b/src/Sail/Middleware/Http/MiddlewareHttpEndpointsBuilder.cs
@@ -21,7 +21,7 @@ public static class MiddlewareHttpEndpointsBuilder
     }
 
     private static async Task<Results<Ok<MiddlewareResponse>, NotFound>> Get(
-        Middleware.MiddlewareService service,
+        MiddlewareService service,
         Guid id,
         CancellationToken cancellationToken)
     {
@@ -30,7 +30,7 @@ public static class MiddlewareHttpEndpointsBuilder
     }
 
     private static async Task<Ok<IEnumerable<MiddlewareResponse>>> List(
-        Middleware.MiddlewareService service,
+        MiddlewareService service,
         string? keywords,
         CancellationToken cancellationToken)
     {
@@ -39,7 +39,7 @@ public static class MiddlewareHttpEndpointsBuilder
     }
 
     private static async Task<Results<Created, ProblemHttpResult>> Create(
-        Middleware.MiddlewareService service,
+        MiddlewareService service,
         MiddlewareRequest request,
         CancellationToken cancellationToken)
     {
@@ -52,7 +52,7 @@ public static class MiddlewareHttpEndpointsBuilder
     }
 
     private static async Task<Results<Ok, ProblemHttpResult>> Update(
-        Middleware.MiddlewareService service,
+        MiddlewareService service,
         Guid id,
         MiddlewareRequest request,
         CancellationToken cancellationToken)
@@ -66,7 +66,7 @@ public static class MiddlewareHttpEndpointsBuilder
     }
 
     private static async Task<Results<Ok, ProblemHttpResult>> Delete(
-        Middleware.MiddlewareService service,
+        MiddlewareService service,
         Guid id,
         CancellationToken cancellationToken)
     {

--- a/src/Sail/Program.cs
+++ b/src/Sail/Program.cs
@@ -1,9 +1,7 @@
 using System.Text.Json.Serialization;
-
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.Metadata;
-
 using Sail.AuthenticationPolicy.Grpc;
 using Sail.AuthenticationPolicy.Http;
 using Sail.Certificate.Grpc;


### PR DESCRIPTION
Removed explicit namespace qualifications from service type parameters in HTTP endpoint builder classes for improved readability. Also cleaned up unused using directives in Program.cs. These changes enhance code clarity and maintainability.