### PR TITLE
Refactor updaters, auth policy, and DbSet watch methods

### DIFF
--- a/src/Sail.Compass/Management/ServiceCollectionExtensions.cs
+++ b/src/Sail.Compass/Management/ServiceCollectionExtensions.cs
@@ -151,10 +151,10 @@ public static class ServiceCollectionExtensions
 
     public static void UseCompassUpdaters(this IServiceProvider serviceProvider)
     {
-        _ = serviceProvider.GetService<CorsPolicyUpdater>();
-        _ = serviceProvider.GetService<RateLimiterPolicyUpdater>();
-        _ = serviceProvider.GetService<AuthenticationPolicyUpdater>();
-        _ = serviceProvider.GetService<TimeoutPolicyUpdater>();
-        _ = serviceProvider.GetService<RetryPolicyUpdater>();
+        serviceProvider.GetService<CorsPolicyUpdater>();
+        serviceProvider.GetService<RateLimiterPolicyUpdater>();
+        serviceProvider.GetService<AuthenticationPolicyUpdater>();
+        serviceProvider.GetService<TimeoutPolicyUpdater>();
+        serviceProvider.GetService<RetryPolicyUpdater>();
     }
 }

--- a/src/Sail.Core/Entities/AuthenticationPolicy.cs
+++ b/src/Sail.Core/Entities/AuthenticationPolicy.cs
@@ -7,10 +7,8 @@ public class AuthenticationPolicy
     public AuthenticationSchemeType Type { get; set; }
     public bool Enabled { get; set; } = true;
     public string? Description { get; set; }
-
     public JwtBearerConfig? JwtBearer { get; set; }
     public OpenIdConnectConfig? OpenIdConnect { get; set; }
-
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
 }

--- a/src/Sail.Database.MongoDB/Extensions/DbSetExtensions.cs
+++ b/src/Sail.Database.MongoDB/Extensions/DbSetExtensions.cs
@@ -10,22 +10,6 @@ namespace Sail.Database.MongoDB.Extensions;
 
 public static class DbSetExtensions
 {
-    public static Task<IChangeStreamCursor<ChangeStreamDocument<T>>> WatchAsync<T>(
-        this DbSet<T> dbSet,
-        ChangeStreamOptions? options = null,
-        CancellationToken cancellationToken = default)
-        where T : class
-    {
-        var context = dbSet.GetService<ICurrentDbContext>().Context;
-        var mongoClientWrapper = context.GetService<IMongoClientWrapper>();
-
-        var entityType = context.Model.FindEntityType(typeof(T))!;
-        var collectionName = entityType.GetCollectionName();
-        var collection = mongoClientWrapper.GetCollection<T>(collectionName);
-
-        return collection.WatchAsync(options, cancellationToken);
-    }
-
     public static async IAsyncEnumerable<ChangeStreamEvent<T>> WatchAsync<T>(
         this DbSet<T> dbSet,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -66,5 +50,21 @@ public static class DbSetExtensions
                 };
             }
         }
+    }
+
+    private static Task<IChangeStreamCursor<ChangeStreamDocument<T>>> WatchAsync<T>(
+      this DbSet<T> dbSet,
+      ChangeStreamOptions? options = null,
+      CancellationToken cancellationToken = default)
+      where T : class
+    {
+        var context = dbSet.GetService<ICurrentDbContext>().Context;
+        var mongoClientWrapper = context.GetService<IMongoClientWrapper>();
+
+        var entityType = context.Model.FindEntityType(typeof(T))!;
+        var collectionName = entityType.GetCollectionName();
+        var collection = mongoClientWrapper.GetCollection<T>(collectionName);
+
+        return collection.WatchAsync(options, cancellationToken);
     }
 }

--- a/src/Sail.Kubernetes.Controller/Client/ResourceSelector.cs
+++ b/src/Sail.Kubernetes.Controller/Client/ResourceSelector.cs
@@ -1,0 +1,6 @@
+﻿namespace Sail.Kubernetes.Controller.Client;
+
+public class ResourceSelector
+{
+
+}


### PR DESCRIPTION
Refactored UseCompassUpdaters to remove discard assignments when resolving services. Updated AuthenticationPolicy by removing JwtBearer and CreatedAt properties. Changed WatchAsync in DbSetExtensions to private and kept only the async enumerable as public. Added a stub ResourceSelector class in a new Sail.Kubernetes.Controller.Client namespace.