### PR TITLE
Refactor auth policy forms, add useDebounce hook

### DIFF
--- a/web/src/hooks/useDebounce.ts
+++ b/web/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/web/src/pages/AuthenticationPolicies/AuthenticationPolicyEdit.tsx
+++ b/web/src/pages/AuthenticationPolicies/AuthenticationPolicyEdit.tsx
@@ -1,33 +1,34 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { ChevronLeftIcon, CheckIcon, PlusIcon, XMarkIcon, KeyIcon, LockClosedIcon } from '@heroicons/react/24/outline';
+import { ChevronLeftIcon, CheckIcon, KeyIcon, LockClosedIcon } from '@heroicons/react/24/outline';
 import { Checkbox } from '../../components/Checkbox';
 import type { AuthenticationSchemeType } from '../../types';
 import { AuthenticationPolicyService } from '../../services/authenticationPolicyService';
+import type { AuthenticationPolicyFormData } from './types';
+import JwtBearerConfigForm from './JwtBearerConfigForm';
+import OpenIdConnectConfigForm from './OpenIdConnectConfigForm';
 
 const AuthenticationPolicyEdit: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const isEdit = id && id !== 'new';
 
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<AuthenticationPolicyFormData>({
     name: '',
     description: '',
-    type: '' as AuthenticationSchemeType | '',
+    type: '',
     enabled: true,
-    // JWT Bearer fields
     jwtAuthority: '',
     jwtAudience: '',
     jwtRequireHttpsMetadata: true,
     jwtSaveToken: false,
-    jwtValidIssuers: [] as string[],
-    jwtValidAudiences: [] as string[],
+    jwtValidIssuers: [],
+    jwtValidAudiences: [],
     jwtValidateIssuer: true,
     jwtValidateAudience: true,
     jwtValidateLifetime: true,
     jwtValidateIssuerSigningKey: true,
     jwtClockSkew: '',
-    // OpenID Connect fields
     oidcAuthority: '',
     oidcClientId: '',
     oidcClientSecret: '',
@@ -35,13 +36,10 @@ const AuthenticationPolicyEdit: React.FC = () => {
     oidcRequireHttpsMetadata: true,
     oidcSaveTokens: true,
     oidcGetClaimsFromUserInfoEndpoint: true,
-    oidcScope: [] as string[],
+    oidcScope: [],
     oidcClockSkew: '',
   });
 
-  const [validIssuerInput, setValidIssuerInput] = useState('');
-  const [validAudienceInput, setValidAudienceInput] = useState('');
-  const [scopeInput, setScopeInput] = useState('');
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -151,56 +149,6 @@ const AuthenticationPolicyEdit: React.FC = () => {
   };
 
 
-  const addValidIssuer = () => {
-    if (validIssuerInput.trim() && !formData.jwtValidIssuers.includes(validIssuerInput.trim())) {
-      setFormData(prev => ({
-        ...prev,
-        jwtValidIssuers: [...prev.jwtValidIssuers, validIssuerInput.trim()]
-      }));
-      setValidIssuerInput('');
-    }
-  };
-
-  const removeValidIssuer = (issuer: string) => {
-    setFormData(prev => ({
-      ...prev,
-      jwtValidIssuers: prev.jwtValidIssuers.filter(i => i !== issuer)
-    }));
-  };
-
-  const addValidAudience = () => {
-    if (validAudienceInput.trim() && !formData.jwtValidAudiences.includes(validAudienceInput.trim())) {
-      setFormData(prev => ({
-        ...prev,
-        jwtValidAudiences: [...prev.jwtValidAudiences, validAudienceInput.trim()]
-      }));
-      setValidAudienceInput('');
-    }
-  };
-
-  const removeValidAudience = (audience: string) => {
-    setFormData(prev => ({
-      ...prev,
-      jwtValidAudiences: prev.jwtValidAudiences.filter(a => a !== audience)
-    }));
-  };
-
-  const addScope = () => {
-    if (scopeInput.trim() && !formData.oidcScope.includes(scopeInput.trim())) {
-      setFormData(prev => ({
-        ...prev,
-        oidcScope: [...prev.oidcScope, scopeInput.trim()]
-      }));
-      setScopeInput('');
-    }
-  };
-
-  const removeScope = (scope: string) => {
-    setFormData(prev => ({
-      ...prev,
-      oidcScope: prev.oidcScope.filter(s => s !== scope)
-    }));
-  };
 
   if (loading) {
     return (
@@ -337,339 +285,12 @@ const AuthenticationPolicyEdit: React.FC = () => {
           </div>
         </div>
 
-        {/* JWT Bearer Configuration */}
         {formData.type === 'JwtBearer' && (
-          <div className="bg-white rounded-lg border border-gray-200 p-6">
-            <div className="flex items-center gap-2 mb-6">
-              <KeyIcon className="h-5 w-5 text-blue-600" />
-              <h2 className="text-base font-semibold text-gray-900">JWT Bearer Configuration</h2>
-            </div>
-            
-            <div className="space-y-5">
-              <div>
-                <label htmlFor="jwtAuthority" className="block text-sm font-medium text-gray-700 mb-2">
-                  Authority <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="url"
-                  id="jwtAuthority"
-                  required
-                  value={formData.jwtAuthority}
-                  onChange={(e) => setFormData(prev => ({ ...prev, jwtAuthority: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                  placeholder="https://your-auth-server.com"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="jwtAudience" className="block text-sm font-medium text-gray-700 mb-2">
-                  Audience <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  id="jwtAudience"
-                  required
-                  value={formData.jwtAudience}
-                  onChange={(e) => setFormData(prev => ({ ...prev, jwtAudience: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                  placeholder="your-api-audience"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Valid Issuers (Optional)
-                </label>
-                <div className="flex gap-2 mb-2">
-                  <input
-                    type="text"
-                    value={validIssuerInput}
-                    onChange={(e) => setValidIssuerInput(e.target.value)}
-                    onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addValidIssuer())}
-                    className="block flex-1 px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                    placeholder="https://issuer.example.com"
-                  />
-                  <button
-                    type="button"
-                    onClick={addValidIssuer}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
-                  >
-                    <PlusIcon className="h-4 w-4" />
-                  </button>
-                </div>
-                {formData.jwtValidIssuers.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {formData.jwtValidIssuers.map((issuer, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center px-3 py-1 bg-blue-50 text-blue-700 text-sm rounded-lg"
-                      >
-                        {issuer}
-                        <button
-                          type="button"
-                          onClick={() => removeValidIssuer(issuer)}
-                          className="ml-2 text-blue-500 hover:text-blue-700"
-                        >
-                          <XMarkIcon className="h-4 w-4" />
-                        </button>
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Valid Audiences (Optional)
-                </label>
-                <div className="flex gap-2 mb-2">
-                  <input
-                    type="text"
-                    value={validAudienceInput}
-                    onChange={(e) => setValidAudienceInput(e.target.value)}
-                    onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addValidAudience())}
-                    className="block flex-1 px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                    placeholder="audience-value"
-                  />
-                  <button
-                    type="button"
-                    onClick={addValidAudience}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
-                  >
-                    <PlusIcon className="h-4 w-4" />
-                  </button>
-                </div>
-                {formData.jwtValidAudiences.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {formData.jwtValidAudiences.map((audience, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center px-3 py-1 bg-blue-50 text-blue-700 text-sm rounded-lg"
-                      >
-                        {audience}
-                        <button
-                          type="button"
-                          onClick={() => removeValidAudience(audience)}
-                          className="ml-2 text-blue-500 hover:text-blue-700"
-                        >
-                          <XMarkIcon className="h-4 w-4" />
-                        </button>
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div>
-                <label htmlFor="jwtClockSkew" className="block text-sm font-medium text-gray-700 mb-2">
-                  Clock Skew (seconds)
-                </label>
-                <input
-                  type="number"
-                  id="jwtClockSkew"
-                  value={formData.jwtClockSkew}
-                  onChange={(e) => setFormData(prev => ({ ...prev, jwtClockSkew: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                  placeholder="300"
-                />
-              </div>
-
-              <div className="pt-4 border-t border-gray-100">
-                <label className="block text-sm font-medium text-gray-700 mb-3">
-                  Validation Options
-                </label>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  <Checkbox
-                    checked={formData.jwtRequireHttpsMetadata}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, jwtRequireHttpsMetadata: checked }))}
-                    label="Require HTTPS metadata"
-                  />
-                  <Checkbox
-                    checked={formData.jwtSaveToken}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, jwtSaveToken: checked }))}
-                    label="Save token"
-                  />
-                  <Checkbox
-                    checked={formData.jwtValidateIssuer}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateIssuer: checked }))}
-                    label="Validate issuer"
-                  />
-                  <Checkbox
-                    checked={formData.jwtValidateAudience}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateAudience: checked }))}
-                    label="Validate audience"
-                  />
-                  <Checkbox
-                    checked={formData.jwtValidateLifetime}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateLifetime: checked }))}
-                    label="Validate lifetime"
-                  />
-                  <Checkbox
-                    checked={formData.jwtValidateIssuerSigningKey}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateIssuerSigningKey: checked }))}
-                    label="Validate signing key"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
+          <JwtBearerConfigForm formData={formData} setFormData={setFormData} />
         )}
 
-        {/* OpenID Connect Configuration */}
         {formData.type === 'OpenIdConnect' && (
-          <div className="bg-white rounded-lg border border-gray-200 p-6">
-            <div className="flex items-center gap-2 mb-6">
-              <LockClosedIcon className="h-5 w-5 text-indigo-600" />
-              <h2 className="text-base font-semibold text-gray-900">OpenID Connect Configuration</h2>
-            </div>
-            
-            <div className="space-y-5">
-              <div>
-                <label htmlFor="oidcAuthority" className="block text-sm font-medium text-gray-700 mb-2">
-                  Authority <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="url"
-                  id="oidcAuthority"
-                  required
-                  value={formData.oidcAuthority}
-                  onChange={(e) => setFormData(prev => ({ ...prev, oidcAuthority: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                  placeholder="https://your-identity-provider.com"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="oidcClientId" className="block text-sm font-medium text-gray-700 mb-2">
-                  Client ID <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  id="oidcClientId"
-                  required
-                  value={formData.oidcClientId}
-                  onChange={(e) => setFormData(prev => ({ ...prev, oidcClientId: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                  placeholder="your-client-id"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="oidcClientSecret" className="block text-sm font-medium text-gray-700 mb-2">
-                  Client Secret <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="password"
-                  id="oidcClientSecret"
-                  required
-                  value={formData.oidcClientSecret}
-                  onChange={(e) => setFormData(prev => ({ ...prev, oidcClientSecret: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                  placeholder="your-client-secret"
-                />
-              </div>
-
-              <div>
-                <label htmlFor="oidcResponseType" className="block text-sm font-medium text-gray-700 mb-2">
-                  Response Type
-                </label>
-                <select
-                  id="oidcResponseType"
-                  value={formData.oidcResponseType}
-                  onChange={(e) => setFormData(prev => ({ ...prev, oidcResponseType: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                >
-                  <option value="code">code</option>
-                  <option value="id_token">id_token</option>
-                  <option value="id_token token">id_token token</option>
-                  <option value="code id_token">code id_token</option>
-                  <option value="code token">code token</option>
-                  <option value="code id_token token">code id_token token</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Scopes
-                </label>
-                <div className="flex gap-2 mb-2">
-                  <input
-                    type="text"
-                    value={scopeInput}
-                    onChange={(e) => setScopeInput(e.target.value)}
-                    onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addScope())}
-                    className="block flex-1 px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                    placeholder="openid, profile, email"
-                  />
-                  <button
-                    type="button"
-                    onClick={addScope}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
-                  >
-                    <PlusIcon className="h-4 w-4" />
-                  </button>
-                </div>
-                {formData.oidcScope.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {formData.oidcScope.map((scope, index) => (
-                      <span
-                        key={index}
-                        className="inline-flex items-center px-3 py-1 bg-indigo-50 text-indigo-700 text-sm rounded-lg"
-                      >
-                        {scope}
-                        <button
-                          type="button"
-                          onClick={() => removeScope(scope)}
-                          className="ml-2 text-indigo-500 hover:text-indigo-700"
-                        >
-                          <XMarkIcon className="h-4 w-4" />
-                        </button>
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div>
-                <label htmlFor="oidcClockSkew" className="block text-sm font-medium text-gray-700 mb-2">
-                  Clock Skew (seconds)
-                </label>
-                <input
-                  type="number"
-                  id="oidcClockSkew"
-                  value={formData.oidcClockSkew}
-                  onChange={(e) => setFormData(prev => ({ ...prev, oidcClockSkew: e.target.value }))}
-                  className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
-                  placeholder="300"
-                />
-              </div>
-
-              <div className="pt-4 border-t border-gray-100">
-                <label className="block text-sm font-medium text-gray-700 mb-3">
-                  Additional Options
-                </label>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  <Checkbox
-                    checked={formData.oidcRequireHttpsMetadata}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, oidcRequireHttpsMetadata: checked }))}
-                    label="Require HTTPS metadata"
-                  />
-                  <Checkbox
-                    checked={formData.oidcSaveTokens}
-                    onChange={(checked) => setFormData(prev => ({ ...prev, oidcSaveTokens: checked }))}
-                    label="Save tokens"
-                  />
-                  <div className="md:col-span-2">
-                    <Checkbox
-                      checked={formData.oidcGetClaimsFromUserInfoEndpoint}
-                      onChange={(checked) => setFormData(prev => ({ ...prev, oidcGetClaimsFromUserInfoEndpoint: checked }))}
-                      label="Get claims from user info endpoint"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          <OpenIdConnectConfigForm formData={formData} setFormData={setFormData} />
         )}
 
         {/* Actions */}

--- a/web/src/pages/AuthenticationPolicies/JwtBearerConfigForm.tsx
+++ b/web/src/pages/AuthenticationPolicies/JwtBearerConfigForm.tsx
@@ -1,0 +1,227 @@
+import React, { useState } from 'react';
+import { PlusIcon, XMarkIcon, KeyIcon } from '@heroicons/react/24/outline';
+import { Checkbox } from '../../components/Checkbox';
+import type { AuthenticationPolicyFormData } from './types';
+
+interface JwtBearerConfigFormProps {
+  formData: AuthenticationPolicyFormData;
+  setFormData: React.Dispatch<React.SetStateAction<AuthenticationPolicyFormData>>;
+}
+
+const JwtBearerConfigForm: React.FC<JwtBearerConfigFormProps> = ({ formData, setFormData }) => {
+  const [validIssuerInput, setValidIssuerInput] = useState('');
+  const [validAudienceInput, setValidAudienceInput] = useState('');
+
+  const addValidIssuer = () => {
+    if (validIssuerInput.trim() && !formData.jwtValidIssuers.includes(validIssuerInput.trim())) {
+      setFormData(prev => ({
+        ...prev,
+        jwtValidIssuers: [...prev.jwtValidIssuers, validIssuerInput.trim()]
+      }));
+      setValidIssuerInput('');
+    }
+  };
+
+  const removeValidIssuer = (issuer: string) => {
+    setFormData(prev => ({
+      ...prev,
+      jwtValidIssuers: prev.jwtValidIssuers.filter(i => i !== issuer)
+    }));
+  };
+
+  const addValidAudience = () => {
+    if (validAudienceInput.trim() && !formData.jwtValidAudiences.includes(validAudienceInput.trim())) {
+      setFormData(prev => ({
+        ...prev,
+        jwtValidAudiences: [...prev.jwtValidAudiences, validAudienceInput.trim()]
+      }));
+      setValidAudienceInput('');
+    }
+  };
+
+  const removeValidAudience = (audience: string) => {
+    setFormData(prev => ({
+      ...prev,
+      jwtValidAudiences: prev.jwtValidAudiences.filter(a => a !== audience)
+    }));
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex items-center gap-2 mb-6">
+        <KeyIcon className="h-5 w-5 text-blue-600" />
+        <h2 className="text-base font-semibold text-gray-900">JWT Bearer Configuration</h2>
+      </div>
+      
+      <div className="space-y-5">
+        <div>
+          <label htmlFor="jwtAuthority" className="block text-sm font-medium text-gray-700 mb-2">
+            Authority <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="url"
+            id="jwtAuthority"
+            required
+            value={formData.jwtAuthority}
+            onChange={(e) => setFormData(prev => ({ ...prev, jwtAuthority: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+            placeholder="https://your-auth-server.com"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="jwtAudience" className="block text-sm font-medium text-gray-700 mb-2">
+            Audience <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="jwtAudience"
+            required
+            value={formData.jwtAudience}
+            onChange={(e) => setFormData(prev => ({ ...prev, jwtAudience: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+            placeholder="your-api-audience"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Valid Issuers (Optional)
+          </label>
+          <div className="flex gap-2 mb-2">
+            <input
+              type="text"
+              value={validIssuerInput}
+              onChange={(e) => setValidIssuerInput(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addValidIssuer())}
+              className="block flex-1 px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+              placeholder="https://issuer.example.com"
+            />
+            <button
+              type="button"
+              onClick={addValidIssuer}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
+            >
+              <PlusIcon className="h-4 w-4" />
+            </button>
+          </div>
+          {formData.jwtValidIssuers.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {formData.jwtValidIssuers.map((issuer, index) => (
+                <span
+                  key={index}
+                  className="inline-flex items-center px-3 py-1 bg-blue-50 text-blue-700 text-sm rounded-lg"
+                >
+                  {issuer}
+                  <button
+                    type="button"
+                    onClick={() => removeValidIssuer(issuer)}
+                    className="ml-2 text-blue-500 hover:text-blue-700"
+                  >
+                    <XMarkIcon className="h-4 w-4" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Valid Audiences (Optional)
+          </label>
+          <div className="flex gap-2 mb-2">
+            <input
+              type="text"
+              value={validAudienceInput}
+              onChange={(e) => setValidAudienceInput(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addValidAudience())}
+              className="block flex-1 px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+              placeholder="audience-value"
+            />
+            <button
+              type="button"
+              onClick={addValidAudience}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
+            >
+              <PlusIcon className="h-4 w-4" />
+            </button>
+          </div>
+          {formData.jwtValidAudiences.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {formData.jwtValidAudiences.map((audience, index) => (
+                <span
+                  key={index}
+                  className="inline-flex items-center px-3 py-1 bg-blue-50 text-blue-700 text-sm rounded-lg"
+                >
+                  {audience}
+                  <button
+                    type="button"
+                    onClick={() => removeValidAudience(audience)}
+                    className="ml-2 text-blue-500 hover:text-blue-700"
+                  >
+                    <XMarkIcon className="h-4 w-4" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="jwtClockSkew" className="block text-sm font-medium text-gray-700 mb-2">
+            Clock Skew (seconds)
+          </label>
+          <input
+            type="number"
+            id="jwtClockSkew"
+            value={formData.jwtClockSkew}
+            onChange={(e) => setFormData(prev => ({ ...prev, jwtClockSkew: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+            placeholder="300"
+          />
+        </div>
+
+        <div className="pt-4 border-t border-gray-100">
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            Validation Options
+          </label>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <Checkbox
+              checked={formData.jwtRequireHttpsMetadata}
+              onChange={(checked) => setFormData(prev => ({ ...prev, jwtRequireHttpsMetadata: checked }))}
+              label="Require HTTPS metadata"
+            />
+            <Checkbox
+              checked={formData.jwtSaveToken}
+              onChange={(checked) => setFormData(prev => ({ ...prev, jwtSaveToken: checked }))}
+              label="Save token"
+            />
+            <Checkbox
+              checked={formData.jwtValidateIssuer}
+              onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateIssuer: checked }))}
+              label="Validate issuer"
+            />
+            <Checkbox
+              checked={formData.jwtValidateAudience}
+              onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateAudience: checked }))}
+              label="Validate audience"
+            />
+            <Checkbox
+              checked={formData.jwtValidateLifetime}
+              onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateLifetime: checked }))}
+              label="Validate lifetime"
+            />
+            <Checkbox
+              checked={formData.jwtValidateIssuerSigningKey}
+              onChange={(checked) => setFormData(prev => ({ ...prev, jwtValidateIssuerSigningKey: checked }))}
+              label="Validate signing key"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default JwtBearerConfigForm;

--- a/web/src/pages/AuthenticationPolicies/OpenIdConnectConfigForm.tsx
+++ b/web/src/pages/AuthenticationPolicies/OpenIdConnectConfigForm.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { PlusIcon, XMarkIcon, LockClosedIcon } from '@heroicons/react/24/outline';
+import { Checkbox } from '../../components/Checkbox';
+import type { AuthenticationPolicyFormData } from './types';
+
+interface OpenIdConnectConfigFormProps {
+  formData: AuthenticationPolicyFormData;
+  setFormData: React.Dispatch<React.SetStateAction<AuthenticationPolicyFormData>>;
+}
+
+const OpenIdConnectConfigForm: React.FC<OpenIdConnectConfigFormProps> = ({ formData, setFormData }) => {
+  const [scopeInput, setScopeInput] = useState('');
+
+  const addScope = () => {
+    if (scopeInput.trim() && !formData.oidcScope.includes(scopeInput.trim())) {
+      setFormData(prev => ({
+        ...prev,
+        oidcScope: [...prev.oidcScope, scopeInput.trim()]
+      }));
+      setScopeInput('');
+    }
+  };
+
+  const removeScope = (scope: string) => {
+    setFormData(prev => ({
+      ...prev,
+      oidcScope: prev.oidcScope.filter(s => s !== scope)
+    }));
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex items-center gap-2 mb-6">
+        <LockClosedIcon className="h-5 w-5 text-indigo-600" />
+        <h2 className="text-base font-semibold text-gray-900">OpenID Connect Configuration</h2>
+      </div>
+      
+      <div className="space-y-5">
+        <div>
+          <label htmlFor="oidcAuthority" className="block text-sm font-medium text-gray-700 mb-2">
+            Authority <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="url"
+            id="oidcAuthority"
+            required
+            value={formData.oidcAuthority}
+            onChange={(e) => setFormData(prev => ({ ...prev, oidcAuthority: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+            placeholder="https://your-identity-provider.com"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="oidcClientId" className="block text-sm font-medium text-gray-700 mb-2">
+            Client ID <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            id="oidcClientId"
+            required
+            value={formData.oidcClientId}
+            onChange={(e) => setFormData(prev => ({ ...prev, oidcClientId: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+            placeholder="your-client-id"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="oidcClientSecret" className="block text-sm font-medium text-gray-700 mb-2">
+            Client Secret <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="password"
+            id="oidcClientSecret"
+            required
+            value={formData.oidcClientSecret}
+            onChange={(e) => setFormData(prev => ({ ...prev, oidcClientSecret: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+            placeholder="your-client-secret"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="oidcResponseType" className="block text-sm font-medium text-gray-700 mb-2">
+            Response Type
+          </label>
+          <select
+            id="oidcResponseType"
+            value={formData.oidcResponseType}
+            onChange={(e) => setFormData(prev => ({ ...prev, oidcResponseType: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+          >
+            <option value="code">code</option>
+            <option value="id_token">id_token</option>
+            <option value="id_token token">id_token token</option>
+            <option value="code id_token">code id_token</option>
+            <option value="code token">code token</option>
+            <option value="code id_token token">code id_token token</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Scopes
+          </label>
+          <div className="flex gap-2 mb-2">
+            <input
+              type="text"
+              value={scopeInput}
+              onChange={(e) => setScopeInput(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addScope())}
+              className="block flex-1 px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+              placeholder="openid, profile, email"
+            />
+            <button
+              type="button"
+              onClick={addScope}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
+            >
+              <PlusIcon className="h-4 w-4" />
+            </button>
+          </div>
+          {formData.oidcScope.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {formData.oidcScope.map((scope, index) => (
+                <span
+                  key={index}
+                  className="inline-flex items-center px-3 py-1 bg-indigo-50 text-indigo-700 text-sm rounded-lg"
+                >
+                  {scope}
+                  <button
+                    type="button"
+                    onClick={() => removeScope(scope)}
+                    className="ml-2 text-indigo-500 hover:text-indigo-700"
+                  >
+                    <XMarkIcon className="h-4 w-4" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="oidcClockSkew" className="block text-sm font-medium text-gray-700 mb-2">
+            Clock Skew (seconds)
+          </label>
+          <input
+            type="number"
+            id="oidcClockSkew"
+            value={formData.oidcClockSkew}
+            onChange={(e) => setFormData(prev => ({ ...prev, oidcClockSkew: e.target.value }))}
+            className="block w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-gray-400 focus:ring-1 focus:ring-gray-400 transition-colors"
+            placeholder="300"
+          />
+        </div>
+
+        <div className="pt-4 border-t border-gray-100">
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            Additional Options
+          </label>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <Checkbox
+              checked={formData.oidcRequireHttpsMetadata}
+              onChange={(checked) => setFormData(prev => ({ ...prev, oidcRequireHttpsMetadata: checked }))}
+              label="Require HTTPS metadata"
+            />
+            <Checkbox
+              checked={formData.oidcSaveTokens}
+              onChange={(checked) => setFormData(prev => ({ ...prev, oidcSaveTokens: checked }))}
+              label="Save tokens"
+            />
+            <div className="md:col-span-2">
+              <Checkbox
+                checked={formData.oidcGetClaimsFromUserInfoEndpoint}
+                onChange={(checked) => setFormData(prev => ({ ...prev, oidcGetClaimsFromUserInfoEndpoint: checked }))}
+                label="Get claims from user info endpoint"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OpenIdConnectConfigForm;

--- a/web/src/pages/AuthenticationPolicies/types.ts
+++ b/web/src/pages/AuthenticationPolicies/types.ts
@@ -1,0 +1,30 @@
+import type { AuthenticationSchemeType } from '../../types';
+
+export interface AuthenticationPolicyFormData {
+  name: string;
+  description: string;
+  type: AuthenticationSchemeType | '';
+  enabled: boolean;
+  // JWT Bearer fields
+  jwtAuthority: string;
+  jwtAudience: string;
+  jwtRequireHttpsMetadata: boolean;
+  jwtSaveToken: boolean;
+  jwtValidIssuers: string[];
+  jwtValidAudiences: string[];
+  jwtValidateIssuer: boolean;
+  jwtValidateAudience: boolean;
+  jwtValidateLifetime: boolean;
+  jwtValidateIssuerSigningKey: boolean;
+  jwtClockSkew: string;
+  // OpenID Connect fields
+  oidcAuthority: string;
+  oidcClientId: string;
+  oidcClientSecret: string;
+  oidcResponseType: string;
+  oidcRequireHttpsMetadata: boolean;
+  oidcSaveTokens: boolean;
+  oidcGetClaimsFromUserInfoEndpoint: boolean;
+  oidcScope: string[];
+  oidcClockSkew: string;
+}

--- a/web/src/pages/Certificates/index.tsx
+++ b/web/src/pages/Certificates/index.tsx
@@ -9,20 +9,22 @@ import {
 } from '@heroicons/react/24/outline';
 import type { Certificate } from '../../types';
 import { CertificateService } from '../../services/certificateService';
+import { useDebounce } from '../../hooks/useDebounce';
 
 const Certificates: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [certificates, setCertificates] = useState<Certificate[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm);
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<{ id: string; name: string } | null>(null);
 
-  const loadCertificates = async () => {
+  const loadCertificates = async (search: string = '') => {
     try {
       setLoading(true);
       setError(null);
-      const data = await CertificateService.getCertificates(searchTerm);
+      const data = await CertificateService.getCertificates(search);
       setCertificates(data);
     } catch (err) {
       console.error('Failed to load certificates:', err);
@@ -37,19 +39,16 @@ const Certificates: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      if (searchTerm !== '') {
-        loadCertificates();
-      }
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchTerm]);
+    if (debouncedSearchTerm !== '') {
+      loadCertificates(debouncedSearchTerm);
+    }
+  }, [debouncedSearchTerm]);
 
   const handleDelete = async (id: string) => {
     try {
       setDeletingId(id);
       await CertificateService.deleteCertificate(id);
-      await loadCertificates();
+      await loadCertificates(searchTerm);
       setDeleteConfirm(null);
     } catch (err) {
       console.error('Failed to delete certificate:', err);
@@ -115,7 +114,7 @@ const Certificates: React.FC = () => {
           <h3 className="text-sm font-medium text-gray-900 mb-1">Failed to load certificates</h3>
           <p className="text-sm text-gray-500 mb-4">Please check your connection and try again</p>
           <button
-            onClick={loadCertificates}
+            onClick={() => loadCertificates(searchTerm)}
             className="inline-flex items-center px-4 py-2 bg-white border border-gray-200 text-sm font-medium rounded-lg hover:bg-gray-50 transition-colors"
           >
             Try Again

--- a/web/src/pages/Clusters/index.tsx
+++ b/web/src/pages/Clusters/index.tsx
@@ -12,20 +12,22 @@ import {
 } from '@heroicons/react/24/outline';
 import type { Cluster } from '../../types';
 import { ClusterService } from '../../services/clusterService';
+import { useDebounce } from '../../hooks/useDebounce';
 
 const Clusters: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [clusters, setClusters] = useState<Cluster[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm);
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<{ id: string; name: string } | null>(null);
 
-  const loadClusters = async () => {
+  const loadClusters = async (search: string = '') => {
     try {
       setLoading(true);
       setError(null);
-      const data = await ClusterService.getClusters(searchTerm);
+      const data = await ClusterService.getClusters(search);
       setClusters(data);
     } catch (err) {
       console.error('Failed to load clusters:', err);
@@ -40,19 +42,16 @@ const Clusters: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      if (searchTerm !== '') {
-        loadClusters();
-      }
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchTerm]);
+    if (debouncedSearchTerm !== '') {
+      loadClusters(debouncedSearchTerm);
+    }
+  }, [debouncedSearchTerm]);
 
   const handleDelete = async (id: string) => {
     try {
       setDeletingId(id);
       await ClusterService.deleteCluster(id);
-      await loadClusters();
+      await loadClusters(searchTerm);
       setDeleteConfirm(null);
     } catch (err) {
       console.error('Failed to delete cluster:', err);
@@ -116,7 +115,7 @@ const Clusters: React.FC = () => {
           <h3 className="text-sm font-medium text-gray-900 mb-1">Failed to load clusters</h3>
           <p className="text-sm text-gray-500 mb-4">Please check your connection and try again</p>
           <button
-            onClick={loadClusters}
+            onClick={() => loadClusters(searchTerm)}
             className="inline-flex items-center px-4 py-2 bg-white border border-gray-200 text-sm font-medium rounded-lg hover:bg-gray-50 transition-colors"
           >
             Try Again

--- a/web/src/pages/Routes/index.tsx
+++ b/web/src/pages/Routes/index.tsx
@@ -8,21 +8,23 @@ import {
 } from '@heroicons/react/24/outline';
 import type { Route } from '../../types';
 import { RouteService } from '../../services/routeService';
+import { useDebounce } from '../../hooks/useDebounce';
 
 const Routes: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [routes, setRoutes] = useState<Route[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm);
   const [filterStatus, setFilterStatus] = useState<'all' | 'active' | 'inactive'>('all');
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<{ id: string; name: string } | null>(null);
 
-  const loadRoutes = async () => {
+  const loadRoutes = async (search: string = '') => {
     try {
       setLoading(true);
       setError(null);
-      const data = await RouteService.getRoutes(searchTerm);
+      const data = await RouteService.getRoutes(search);
       setRoutes(data);
     } catch (err) {
       console.error('Failed to load routes:', err);
@@ -37,19 +39,16 @@ const Routes: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      if (searchTerm !== '') {
-        loadRoutes();
-      }
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchTerm]);
+    if (debouncedSearchTerm !== '') {
+      loadRoutes(debouncedSearchTerm);
+    }
+  }, [debouncedSearchTerm]);
 
   const handleDelete = async (id: string) => {
     try {
       setDeletingId(id);
       await RouteService.deleteRoute(id);
-      await loadRoutes();
+      await loadRoutes(searchTerm);
       setDeleteConfirm(null);
     } catch (err) {
       console.error('Failed to delete route:', err);
@@ -132,7 +131,7 @@ const Routes: React.FC = () => {
           <h3 className="text-sm font-medium text-gray-900 mb-1">Failed to load routes</h3>
           <p className="text-sm text-gray-500 mb-4">Please check your connection and try again</p>
           <button
-            onClick={loadRoutes}
+            onClick={() => loadRoutes(searchTerm)}
             className="inline-flex items-center px-4 py-2 bg-white border border-gray-200 text-sm font-medium rounded-lg hover:bg-gray-50 transition-colors"
           >
             Try Again


### PR DESCRIPTION
Extracted JWT and OIDC config sections into separate components for better modularity in AuthenticationPolicyEdit. Added a reusable useDebounce hook and applied it to Certificates, Clusters, and Routes search fields. Introduced a shared form data type for authentication policies. Improved code organization and search performance across list pages.